### PR TITLE
Update schema.prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,14 @@
 generator client {
     provider        = "prisma-client-js"
+    // Preview feature "referentialIntegrity" is deprecated. The functionality can be used without specifying it as a preview feature.
     previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {
     provider             = "mysql"
     url                  = env("DATABASE_URL")
-    referentialIntegrity = "prisma"
+    // The `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode
+    relationMode = "prisma"
 }
 
 model Product {


### PR DESCRIPTION
In the client the preview feature is now GA, no longer needed as a preview feature.  On the datasource `referentialIntegrity` is @deprecated.  Should now use relationMode.  I included the comments, updates, or links.